### PR TITLE
Bugfix: Specify archive extension to avoid catching sha512sum links

### DIFF
--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Get the latest Proton-GE-Custom release (url and filename)
-url="$(curl -s "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest" | grep "browser_download_url" | grep "\.tar\.gz" | cut -d \" -f 4)"
+url="$(curl -s "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest" | grep "browser_download_url.*\.tar\.gz" | cut -d \" -f 4)"
 filename="$(echo "$url" | sed "s|.*/||")"
 
 # Installation routine

--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Get the latest Proton-GE-Custom release (url and filename)
-url="$(curl -s "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest" | grep "browser_download_url" | cut -d \" -f 4)"
+url="$(curl -s "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest" | grep "browser_download_url" | grep "\.tar\.gz" | cut -d \" -f 4)"
 filename="$(echo "$url" | sed "s|.*/||")"
 
 # Installation routine


### PR DESCRIPTION
This pull request includes ~two~ three commits: 
- The aforementioned bugfix
- A second commit, which uses that checksum (when available) to verify the integrity of the archive.
- A single-call rewrite of the grep fix.

I wrote it to ask for user input when a checksum fails if possible, but to otherwise fail silently, which I would personally change (adding a flag for those who do want silent failure), but I'm hesitant to add any flags or force a failure case on a project that isn't mine; the modifications required to do so are simple enough, and, like most users, I just wanted the updater to work tonight :p