### PR TITLE
Exit on archive integrity failures

### DIFF
--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -39,13 +39,14 @@ install() {
         # Verify file integrity if sha512sum is availible and a hash can be obtained
         if hash sha512sum && sha512_hash=$(curl -Lf "${url%.tar.gz}.sha512sum" 2>/dev/null); then
             echo "--> Verfiying file integrity..."
-            if ! sha512sum -c <<< "${sha512_hash%% *}  ${filename}"; then
-                # If the session is interactive, we ask whether
+            if ! printf '%s' "${sha512_hash%% *}  ${filename}" | sha512sum -c /dev/stdin; then
+                # If stdin is a terminal, we ask whether
                 # or not to accept a failed checksum,
                 # but otherwise exit.
-                if [[ -v PS1 ]] || [[ $- = *i* ]]; then
+                if [ -t 0 ]; then
                     while true; do
-                        read -p "--> File integrity check failed. Continue? (y/[N]) "
+                        printf '%s' "--> File integrity check failed. Continue?  (y/[N]) "
+                        read -r REPLY
                         case "$REPLY" in
                             [yY][eE][sS]|[yY]) break ;;
                             [nN][oO]|[nN]|'') exit 1 ;;

--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -38,26 +38,27 @@ install() {
         curl -L "$url" --output "$filename"
         # Verify file integrity if sha512sum is availible and a hash can be obtained
         if hash sha512sum && sha512_hash=$(curl -Lf "${url%.tar.gz}.sha512sum" 2>/dev/null); then
-          echo "--> Verfiying file integrity..."
-          if ! sha512sum -c <<< "${sha512_hash%% *}  ${filename}"; then
-            # If the session is interactive, we ask the user whether or not to accept a failed checksum,
-            # but otherwise exit.
-            if [[ -v PS1 ]] || [[ $- = *i* ]]; then
-              while true; do
-                read -p "--> File integrity check failed. Continue? (y/[N]) "
-                case "$REPLY" in
-                  [yY][eE][sS]|[yY]) break ;;
-                  [nN][oO]|[nN]|'') exit 1 ;;
-                  *) echo "Invalid input..." ;;
-                esac
-              done
-            else
-              echo "--> ERROR: File integrity check failed." 1>&2
-              exit 1
+            echo "--> Verfiying file integrity..."
+            if ! sha512sum -c <<< "${sha512_hash%% *}  ${filename}"; then
+                # If the session is interactive, we ask whether
+                # or not to accept a failed checksum,
+                # but otherwise exit.
+                if [[ -v PS1 ]] || [[ $- = *i* ]]; then
+                    while true; do
+                        read -p "--> File integrity check failed. Continue? (y/[N]) "
+                        case "$REPLY" in
+                            [yY][eE][sS]|[yY]) break ;;
+                            [nN][oO]|[nN]|'') exit 1 ;;
+                            *) echo "Invalid input..." ;;
+                        esac
+                    done
+                else
+                    echo "--> ERROR: File integrity check failed." 1>&2
+                    exit 1
+                fi
             fi
-          fi
-        else
-          echo "--> Skipping file integrity check (hash not found)."
+          else
+              echo "--> Skipping file integrity check (hash not found)."
         fi
         echo "--> Extracting $filename..."
         tar -xf "$filename"

--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -41,18 +41,19 @@ install() {
           echo "--> Verfiying file integrity..."
           if ! sha512sum -c <<< "${sha512_hash%% *}  ${filename}"; then
             # If the session is interactive, we ask the user whether or not to accept a failed checksum,
-            # but permissively default to continuing if the session is not interactive or no response is given.
+            # but otherwise exit.
             if [[ -v PS1 ]] || [[ $- = *i* ]]; then
               while true; do
-                read -p "--> File integrity check failed. Continue? ([Y]/n) "
+                read -p "--> File integrity check failed. Continue? (y/[N]) "
                 case "$REPLY" in
-                  [yY][eE][sS]|[yY]|'') break ;;
-                  [nN][oO]|[nN]) exit 1 ;;
+                  [yY][eE][sS]|[yY]) break ;;
+                  [nN][oO]|[nN]|'') exit 1 ;;
                   *) echo "Invalid input..." ;;
                 esac
               done
             else
-              echo "--> WARNING: File integrity check failed."
+              echo "--> ERROR: File integrity check failed." 1>&2
+              exit 1
             fi
           fi
         else


### PR DESCRIPTION
* Upgrade invalid archives from warnings to errors, defaulting to a hard exit
* Redirect relevent notice to stderr
* Update comments and prompts appropriately