### PR TITLE
Delete old versions of Proton-GE except latest & previous

### DIFF
--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -65,7 +65,7 @@ install() {
         tar -xf "$filename"
         echo "--> Removing the compressed archive & older versions of Proton-GE..."
         rm "$filename"
-         ls -d GE-Proton* | head -n -2 | xargs -r rm -r
+        ls -d GE-Proton* | head -n -2 | xargs -r rm -r
         echo "--> Done. Please check the command line for errors and restart Steam for the changes to take effect."
         return 0
     fi

--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -63,8 +63,9 @@ install() {
         fi
         echo "--> Extracting $filename..."
         tar -xf "$filename"
-        echo "--> Removing the compressed archive..."
+        echo "--> Removing the compressed archive & older versions of Proton-GE..."
         rm "$filename"
+         ls -d GE-Proton* | head -n -2 | xargs -r rm -r
         echo "--> Done. Please check the command line for errors and restart Steam for the changes to take effect."
         return 0
     fi

--- a/proton-ge-custom-updater.sh
+++ b/proton-ge-custom-updater.sh
@@ -65,7 +65,7 @@ install() {
         tar -xf "$filename"
         echo "--> Removing the compressed archive & older versions of Proton-GE..."
         rm "$filename"
-        ls -d GE-Proton* | head -n -2 | xargs -r rm -r
+        ls -d -v GE-Proton* | head -n -2 | xargs -r rm -r
         echo "--> Done. Please check the command line for errors and restart Steam for the changes to take effect."
         return 0
     fi


### PR DESCRIPTION
Should partially solve "Automatically update steam configurations and remove old versions".

This assures that you will not get your storage trashed with 50 versions of Proton-GE over time.

Previous version is needed for seamless transition to newer Proton version. Unless automatic enabling of latest Proton-GE in Steam settings is implemented.

This is for Proton-GE only, I may try to implement support for others.